### PR TITLE
Fix game_results.php returning an old season's results.

### DIFF
--- a/www/game_results.php
+++ b/www/game_results.php
@@ -52,7 +52,8 @@
 		`participants` AS `participant2`,
 		`members` AS `author2`,
 		`results`
-		WHERE `results`.`seasonid`='6'
+		INNER JOIN seasonids on seasonids.id = results.seasonid 
+		WHERE seasonids.Current = 1
 		AND `results`.`Bot1`= `participant1`.`ID`
 		AND `participant1`.`Author` = `author1`.`id`
 		AND `results`.`Bot2` = `participant2`.`ID`


### PR DESCRIPTION
Season was hard-coded.
This makes it return results from the season flagged as "Current".
It could probably even ignore the season but I figured this was the smaller change for now to get it working.