### PR TITLE
Round Robin Matchups within the ELO range.

### DIFF
--- a/www/GetNextMatch.php
+++ b/www/GetNextMatch.php
@@ -4,6 +4,7 @@ $races[1] = "Zerg";
 $races[2] = "Protoss";
 $races[3] = "Random";
 $skipping_per = 20;  //percentage of battles skipped to create opponent mixture.
+$new_skipping_per = 50;  //percentage of battles skipped to create opponent mixture.
 
 require_once("dbconf.php");
 $link = new mysqli($host, $username, $password , $db_name);
@@ -81,6 +82,9 @@ if($firstrow)
 		}
 		else
 		{
+			if (rand(0,100) <= $new_skipping_per) {
+				continue;
+			}			
 			$secondrow = $row;
 			break;
 		}

--- a/www/GetNextMatch.php
+++ b/www/GetNextMatch.php
@@ -3,6 +3,7 @@ $races[0] = "Terran";
 $races[1] = "Zerg";
 $races[2] = "Protoss";
 $races[3] = "Random";
+$skipping_per = 20;  //percentage of battles skipped to create opponent mixture.
 
 require_once("dbconf.php");
 $link = new mysqli($host, $username, $password , $db_name);
@@ -24,23 +25,29 @@ if(!password_verify($_REQUEST["Password"], $usersrow["password"]))
 	echo "User no verified for requesting matches";
 	exit();
 }
-$sql = "SELECT * FROM `matches` ORDER BY `MatchTime` DESC";
+$sql = "SELECT * FROM `participants` WHERE `Deactivated`='0' AND `Deleted`='0' ORDER BY RAND()";
+$firstrow;
+$oldest = 0;
 $result = $link->query($sql);
-$LastId = 0;
-if($firstrow = $result->fetch_array(MYSQLI_ASSOC))
+while($row = $result->fetch_array())
 {
-	$LastId = $firstrow["Bot1ID"];
+	$sql = "SELECT * FROM `matches` WHERE `Bot1ID`='" .$row["ID"] . "' OR `Bot2ID`='" .$row["ID"] . "'";
+	$sql .= " ORDER BY `MatchTime` DESC LIMIT 1";
+	$match_result = $link->query($sql);
+	if($match = $match_result->fetch_array(MYSQLI_ASSOC))
+	{
+		if ($oldest == 0 || $match['MatchTime'] < $oldest)
+		{
+			$oldest = $match['MatchTime'];
+			$firstrow = $row;
+		}
+	}
+	else
+	{
+		$firstrow = $row;
+		break;
+	}
 }
-$sql = "SELECT * FROM `participants` WHERE `Deactivated`='0' AND `Deleted`='0' AND `ID` > '" . $LastId . "' ORDER BY `ID` ASC LIMIT 1";
-$firstResult = $link->query($sql);
-$firstrow = $firstResult->fetch_array(MYSQLI_ASSOC);
-if(!$firstrow)
-{
-	$sql = "SELECT * FROM `participants` WHERE `Deactivated`='0' AND `Deleted`='0' ORDER BY `ID` ASC LIMIT 1";
-	$firstResult = $link->query($sql);
-	$firstrow = $firstResult->fetch_array(MYSQLI_ASSOC);
-}
-
 if($firstrow)
 {
 	$sql = "SELECT * FROM `participants` WHERE `Deactivated`='0' AND `Deleted`='0' AND `ID` != '" .$firstrow["ID"] . "'";
@@ -50,9 +57,35 @@ if($firstrow)
 		$maxELO = $firstrow["CurrentELO"] + 300;
 		$sql .= " AND ((`CurrentELO` > '" . $minELO . "' AND `CurrentELO` < '" . $maxELO . "') OR `CurrentELO`='0')";
 	}
-	$sql .= " ORDER BY RAND() LIMIT 1";
-	$secondResult = $link->query($sql);
-	if($secondrow = $secondResult->fetch_array(MYSQLI_ASSOC))
+	$sql .= " ORDER BY RAND()";
+	$eligible = $link->query($sql);
+	$secondrow;
+	$best_opp_last = 0;
+	while($row = $eligible->fetch_array())
+	{
+		$opp_id = $row['ID'];
+		$sql = "SELECT * FROM `matches` WHERE (`Bot1ID`='" .$firstrow["ID"] . "' AND `Bot2ID`='" .$row["ID"] . "')";
+		$sql .= " OR (`Bot1ID`='" .$row["ID"] . "' AND `Bot2ID`='" .$firstrow["ID"] . "')";
+		$sql .= " ORDER BY `MatchTime` DESC LIMIT 1";
+		$opp_result = $link->query($sql);
+		if($match = $opp_result->fetch_array(MYSQLI_ASSOC))
+		{
+			if (rand(0,100) <= $skipping_per) {
+				continue;
+			}
+			if ($best_opp_last == 0 || $match['MatchTime'] < $best_opp_last)
+			{
+				$best_opp_last = $match['MatchTime'];
+				$secondrow = $row;
+			}
+		}
+		else
+		{
+			$secondrow = $row;
+			break;
+		}
+	}
+	if($secondrow)
 	{
 		$sql  = "SELECT * FROM `maps` WHERE `Active`='1' ORDER BY RAND() LIMIT 1";
 		$mapsResult = $link->query($sql);


### PR DESCRIPTION
Bot1 is the bot that has gone the longest without a battle.
Bot2 is the bot that has gone the longest without a battle against Bot1

The $skipping_per is to create some randomness in the battle order to prevent predictability and to keep new bots and reactivated bots from having battles clumped together since they will by default by Bot2 until they've played all the bots.      Battles are not permanently skipped they are just delayed, keeping the overall structure and balance in tact for the most part.   100 value will put result in an endless loop, don't do it.